### PR TITLE
More robust file move, was failing on some OSs

### DIFF
--- a/src/main/groovy/com/droidtitan/lintcleaner/LintCleanerTask.groovy
+++ b/src/main/groovy/com/droidtitan/lintcleaner/LintCleanerTask.groovy
@@ -101,8 +101,15 @@ class LintCleanerTask extends DefaultTask {
         }
       }
 
-      tempFile.renameTo(sourceFile)
-      println "Removed entries from $sourceFile.name"
+      sourceFile.setWritable(true);
+      sourceFile.delete();
+      if( tempFile.renameTo(sourceFile) ) {
+        println "Removed entries from $sourceFile.name"
+      }
+      else {
+        tempFile.delete();
+        println "Failed to remove entries from $sourceFile.name"
+      }
     }
   }
 }


### PR DESCRIPTION
Silent failure of the final file move on Windows was causing problems.

Now move failures will be reported, and the move in general is more robust and succeeds where it previously failed.

In the case where the move does fail, the temp file is deleted, other wise it leaves the project in an unbuild-able state.
