### PR TITLE
fixed: xml drawable destoryed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 classes
 local.properties
 .DS_Store
+.gradletasknamecache

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'maven'
 apply plugin: 'nexus'
 
 group = 'com.droidtitan'
-version = '0.3.0'
+version = '0.3.1'
 
 dependencies {
   repositories {

--- a/src/main/groovy/com/droidtitan/lintcleaner/LintCleanerTask.groovy
+++ b/src/main/groovy/com/droidtitan/lintcleaner/LintCleanerTask.groovy
@@ -25,6 +25,7 @@ class LintCleanerTask extends DefaultTask {
   List<String> excludes
   String lintXmlFilePath
   boolean ignoreResFiles
+  boolean ignoreDrawableFiles
 
   LintCleanerTask() {
     group = LintCleanerPlugin.GROUP
@@ -56,7 +57,6 @@ class LintCleanerTask extends DefaultTask {
 
       if (issue.getAttribute(ID_XML_TAG).equals(UNUSED_RESOURCES_ID)) {
         NodeList locations = issue.getElementsByTagName(LOCATION_XML_TAG)
-
         if (locations.length == 1) {
           processLocation(locations.item(0) as Element)
         } else {
@@ -73,7 +73,7 @@ class LintCleanerTask extends DefaultTask {
     String line = location.getAttribute(LINE_XML_TAG)
     String filePath = location.getAttribute(FILE_PATH_XML_TAG)
 
-    if (line.empty) {
+    if (notValuesRes(filePath) || line.empty) {
       File file = new File(filePath)
       file.delete()
       println "Removed $file.name"
@@ -83,6 +83,13 @@ class LintCleanerTask extends DefaultTask {
       lineNumbers.add(line)
       filePathToLines.put(filePath, lineNumbers)
     }
+  }
+
+
+
+  // If a unused resources is a string reference or color reference
+  boolean notValuesRes(String filePath){
+    return !filePath.contains("res/values/")
   }
 
   /** Removes unused resources from single files like strings.xml, color.xml etc. */


### PR DESCRIPTION
Signed-off-by: Desert zyallday@gmail.com
Hi， marcoRS
I recently found that this plugin would destroy drawables which write by xml. I checked the source code,and I found when a xml-drawable is unused the tag location is like this:

`<location file="path/to/file" line="3" column="2">`

then it will be added into the `filePathToLines`, so I fixed it
